### PR TITLE
Implement iOS keyboard audio recording

### DIFF
--- a/ios/AutoQuillKeyboard/KeyboardViewController.swift
+++ b/ios/AutoQuillKeyboard/KeyboardViewController.swift
@@ -72,6 +72,9 @@ class KeyboardViewController: UIInputViewController {
     // Push-to-talk gesture tracking
     private var pushToTalkStartTime: Date?
     private let minimumPushToTalkDuration: TimeInterval = 0.1 // 100ms minimum
+
+    /// Handles all audio recording operations.
+    private let recordingManager = RecordingManager()
     
     // MARK: - Lifecycle
     override func viewDidLoad() {
@@ -371,6 +374,15 @@ class KeyboardViewController: UIInputViewController {
         let impactFeedback = UIImpactFeedbackGenerator(style: .medium)
         impactFeedback.impactOccurred()
         
+        if selectedMode == .handsFree {
+            do {
+                try recordingManager.startRecording()
+            } catch {
+                print("Error starting recording: \(error)")
+                return
+            }
+        }
+
         showRecordingControls(for: selectedMode)
     }
     
@@ -382,13 +394,26 @@ class KeyboardViewController: UIInputViewController {
         let impactFeedback = UIImpactFeedbackGenerator(style: .light)
         impactFeedback.impactOccurred()
         
-        // For now, just print the action (we'll implement backend logic later)
-        print("🎯 \(buttonName) button tapped!")
-        
-        // If cancel or stop, go back to mode selection
-        if sender.tag == 1 || sender.tag == 2 { // Stop or Cancel
+        switch sender.tag {
+        case 0: // Pause
+            recordingManager.pauseRecording()
+        case 1: // Stop
+            recordingManager.stopRecording()
             showModeSelection()
+        case 2: // Cancel
+            recordingManager.cancelRecording()
+            showModeSelection()
+        case 3: // Restart
+            do {
+                try recordingManager.restartRecording()
+            } catch {
+                print("Error restarting recording: \(error)")
+            }
+        default:
+            break
         }
+
+        print("🎯 \(buttonName) button tapped!")
     }
     
     // MARK: - Button Animations

--- a/ios/AutoQuillKeyboard/RecordingManager.swift
+++ b/ios/AutoQuillKeyboard/RecordingManager.swift
@@ -1,0 +1,104 @@
+import Foundation
+import AVFoundation
+
+/// Manages audio recording for the AutoQuill keyboard extension.
+/// This class encapsulates the `AVAudioRecorder` setup and control logic
+/// so that the `KeyboardViewController` remains focused on UI concerns.
+final class RecordingManager: NSObject {
+    /// Shared audio session for recording.
+    private let audioSession = AVAudioSession.sharedInstance()
+
+    /// Underlying audio recorder instance.
+    private var recorder: AVAudioRecorder?
+
+    /// URL of the current recording file.
+    private var recordingURL: URL?
+
+    /// App group identifier used for storing recordings.
+    private let appGroupID = "group.com.divyansh-lalwani.autoquill-ai.shared"
+
+    /// Directory where recordings are stored (``AutoQuill`` folder).
+    private lazy var recordingsDirectory: URL? = {
+        guard let container = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroupID) else {
+            return nil
+        }
+        let dir = container.appendingPathComponent("AutoQuill")
+        if !FileManager.default.fileExists(atPath: dir.path) {
+            try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true, attributes: nil)
+        }
+        return dir
+    }()
+
+    /// Starts a new recording session.
+    func startRecording() throws {
+        try configureSession()
+
+        guard let recordingsDirectory, let fileURL = generateRecordingURL(in: recordingsDirectory) else {
+            throw RecordingError.unableToCreateFile
+        }
+        recordingURL = fileURL
+
+        let settings: [String: Any] = [
+            AVFormatIDKey: Int(kAudioFormatMPEG4AAC),
+            AVSampleRateKey: 44100,
+            AVNumberOfChannelsKey: 1,
+            AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue
+        ]
+
+        recorder = try AVAudioRecorder(url: fileURL, settings: settings)
+        recorder?.delegate = self
+        recorder?.isMeteringEnabled = true
+        guard recorder?.record() == true else {
+            throw RecordingError.unableToStart
+        }
+    }
+
+    /// Pauses the current recording if possible.
+    func pauseRecording() {
+        recorder?.pause()
+    }
+
+    /// Stops recording and finalises the audio file.
+    func stopRecording() {
+        recorder?.stop()
+    }
+
+    /// Cancels the recording and discards the audio file.
+    func cancelRecording() {
+        recorder?.stop()
+        if let url = recordingURL {
+            try? FileManager.default.removeItem(at: url)
+        }
+    }
+
+    /// Restarts the recording by cancelling the current session and starting a new one.
+    func restartRecording() throws {
+        cancelRecording()
+        try startRecording()
+    }
+
+    /// Configures the AVAudioSession for recording.
+    private func configureSession() throws {
+        try audioSession.setCategory(.playAndRecord, mode: .default, options: [.defaultToSpeaker])
+        try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
+    }
+
+    /// Generates a unique file URL for the recording.
+    private func generateRecordingURL(in directory: URL) -> URL? {
+        let formatter = ISO8601DateFormatter()
+        let dateString = formatter.string(from: Date())
+        return directory.appendingPathComponent("Recording_\(dateString).m4a")
+    }
+
+    enum RecordingError: Error {
+        case unableToCreateFile
+        case unableToStart
+    }
+}
+
+extension RecordingManager: AVAudioRecorderDelegate {
+    func audioRecorderEncodeErrorDidOccur(_ recorder: AVAudioRecorder, error: Error?) {
+        print("Recording error: \(error?.localizedDescription ?? "unknown")")
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `RecordingManager` to handle AVFoundation recording
- integrate recording manager with `KeyboardViewController`
- implement start, pause, stop, cancel and restart controls for hands‑free mode

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840b323d9fc83319684789c99de6c13